### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: yarn install && yarn run build
+    command: yarn run start

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jdhorwitz/stjoes) 
+
 [![CircleCI Status](https://circleci.com/gh/jdhorwitz/stjoes.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/jdhorwitz/stjoes)
 
 Website for Saturday Night at St Joes.


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.